### PR TITLE
Add rudimentary support for boost::posix_time::ptime

### DIFF
--- a/boost/v1_40/printers.py
+++ b/boost/v1_40/printers.py
@@ -606,6 +606,26 @@ class BoostGregorianDate:
         year = 100*b + d - 4800 + (m/10)
         return '(%s) %4d-%02d-%02d' % (self.typename, year,month,day)
 
+@register_pretty_printer
+class BoostPosixTimePTime:
+    "Pretty Printer for boost::posix_time::ptime"
+    regex = re.compile('^boost::posix_time::ptime$')
+
+    @static
+    def supports(typename):
+        return BoostPosixTimePTime.regex.search(typename)
+
+    def __init__(self, typename, value):
+        self.typename = typename
+        self.value = value
+
+    def to_string(self):
+        n = int(self.value['time_']['time_count_']['value_'])
+        # Check for uninitialized case
+        if n==2**63-2:
+            return '(%s) uninitialized' % self.typename
+        # Represent time in a raw fashion
+        return '(%s) %d' % (self.typename, n)
 
 def register_boost_printers(obj):
     "Register Boost Pretty Printers."


### PR DESCRIPTION
This presents ptime as a big integer rather than a human-readable string. I'm not sure of a safe and reliable method of turning this into a human readable string in some default (UTC?) timezone. 

However, this is still better than the paragraph of noise gdb prints without this pretty printer. 
