### PR TITLE
Fix name clash problems with intrusive iterators.

### DIFF
--- a/boost/printers.py
+++ b/boost/printers.py
@@ -510,56 +510,10 @@ def intrusive_iterator_to_string(iterator_value):
     if member_hook_traits:
         value_type = member_hook_traits.template_argument(0)
         member_offset = member_hook_traits.template_argument(2).cast(gdb.lookup_type("size_t"))
-        currentElementAddress = iterator_value["members_"]["nodeptr_"].cast(gdb.lookup_type("size_t")) - member_offset
-        return currentElementAddress.cast(value_type.pointer()).dereference()
+        current_element_address = iterator_value["members_"]["nodeptr_"].cast(gdb.lookup_type("size_t")) - member_offset
+        return current_element_address.cast(value_type.pointer()).dereference()
 
     return iterator_value["members_"]["nodeptr_"]
-
-
-class BoostIntrusiveRbtreeIterator:
-    def __init__(self, rbTreeHeader, elementPointerType, memberOffset=0):
-        self.header = rbTreeHeader
-        self.memberOffset = memberOffset
-        if memberOffset == 0:
-            self.nodeType = elementPointerType
-        else:
-            self.nodeType = gdb.lookup_type("boost::intrusive::rbtree_node<void*>").pointer();
-            self.elementPointerType = elementPointerType
-        self.node = rbTreeHeader['left_'].cast(self.nodeType)
-
-    def __iter__(self):
-        return self
-
-    def getElementPointerFromNodePointer(self):
-        if self.memberOffset == 0:
-            return self.node
-        else:
-            currentElementAddress = self.node.cast(gdb.lookup_type("size_t")) - self.memberOffset
-            return currentElementAddress.cast(self.elementPointerType)
-
-    def next(self):
-        # empty set or reached rightmost leaf
-        if not self.node:
-            raise StopIteration
-        result = self.getElementPointerFromNodePointer()
-        if self.node != self.header["right_"].cast(self.nodeType):
-            # Compute the next node.
-            node = self.node
-            if node.dereference()['right_']:
-                node = node.dereference()['right_']
-                while node.dereference()['left_']:
-                    node = node.dereference()['left_']
-            else:
-                parent = node.dereference()['parent_']
-                while node == parent.dereference()['right_']:
-                    node = parent
-                    parent = parent.dereference()['parent_']
-                if node.dereference()['right_'] != parent:
-                    node = parent
-            self.node = node.cast(self.nodeType)
-        else:
-            self.node = 0
-        return result
 
 @_register_printer
 class BoostIntrusiveSet:
@@ -568,16 +522,55 @@ class BoostIntrusiveSet:
     version = '1.40'
     type_name_re = '^boost::intrusive::set<.*>$'
 
-    class _iter:
-        def __init__(self, rbiter):
-            self.rbiter = rbiter
+    class Iterator:
+        def __init__(self, rb_tree_header, element_pointer_type, member_offset=0):
+            self.header = rb_tree_header
+            self.member_offset = member_offset
+            if member_offset == 0:
+                self.node_type = element_pointer_type
+            else:
+                self.node_type = gdb.lookup_type("boost::intrusive::rbtree_node<void*>").pointer();
+                self.element_pointer_type = element_pointer_type
+
+            if rb_tree_header['parent_']:
+                self.node = rb_tree_header['left_'].cast(self.node_type)
+            else:
+                self.node = 0
+
             self.count = 0
 
         def __iter__(self):
             return self
 
+        def get_element_pointer_from_node_pointer(self):
+            if self.member_offset == 0:
+                return self.node
+            else:
+                current_element_address = self.node.cast(gdb.lookup_type("size_t")) - self.member_offset
+                return current_element_address.cast(self.element_pointer_type)
+
         def next(self):
-            item = self.rbiter.next().dereference()
+            # empty set or reached rightmost leaf
+            if not self.node:
+                raise StopIteration
+            item = self.get_element_pointer_from_node_pointer().dereference()
+            if self.node != self.header["right_"].cast(self.node_type):
+                # Compute the next node.
+                node = self.node
+                if node.dereference()['right_']:
+                    node = node.dereference()['right_']
+                    while node.dereference()['left_']:
+                        node = node.dereference()['left_']
+                else:
+                    parent = node.dereference()['parent_']
+                    while node == parent.dereference()['right_']:
+                        node = parent
+                        parent = parent.dereference()['parent_']
+                    if node.dereference()['right_'] != parent:
+                        node = parent
+                self.node = node.cast(self.node_type)
+            else:
+                self.node = 0
             result = ('[%d]' % self.count, item)
             self.count = self.count + 1
             return result
@@ -585,38 +578,38 @@ class BoostIntrusiveSet:
     def __init__(self, value):
         self.typename = value.type_name
         self.val = value
-        self.elementType = self.val.type.strip_typedefs().template_argument(0)
+        self.element_type = self.val.type.strip_typedefs().template_argument(0)
 
-    def getHeader(self):
+    def get_header(self):
         return self.val["tree_"]["data_"]["node_plus_pred_"]["header_plus_size_"]["header_"]
 
-    def getSize(self):
+    def get_size(self):
         return self.val["tree_"]["data_"]["node_plus_pred_"]["header_plus_size_"]["size_"]
 
-    def hasElements(self):
-        header = self.getHeader()
-        firstElement = header["parent_"]
-        if firstElement:
+    def has_elements(self):
+        header = self.get_header()
+        first_element = header["parent_"]
+        if first_element:
             return True
         else:
             return False
 
     def to_string (self):
         if (intrusive_container_has_size_member(self.val.type)):
-            return "boost::intrusive::set<%s> with %d elements" % (self.elementType, self.getSize())
-        elif (self.hasElements()):
-            return "non-empty boost::intrusive::set<%s>" % self.elementType
+            return "boost::intrusive::set<%s> with %d elements" % (self.element_type, self.get_size())
+        elif (self.has_elements()):
+            return "non-empty boost::intrusive::set<%s>" % self.element_type
         else:
-            return "empty boost::intrusive::set<%s>" % self.elementType
+            return "empty boost::intrusive::set<%s>" % self.element_type
 
     def children (self):
-        elementPointerType = self.elementType.pointer()
+        element_pointer_type = self.element_type.pointer()
         member_hook = get_named_template_argument(self.val.type, "boost::intrusive::member_hook")
         if member_hook:
-            memberOffset = member_hook.template_argument(2).cast(gdb.lookup_type("size_t"))
-            return self._iter (BoostIntrusiveRbtreeIterator(self.getHeader(), elementPointerType, memberOffset))
+            member_offset = member_hook.template_argument(2).cast(gdb.lookup_type("size_t"))
+            return self.Iterator(self.get_header(), element_pointer_type, member_offset)
         else:
-            return self._iter (BoostIntrusiveRbtreeIterator(self.getHeader(), elementPointerType))
+            return self.Iterator(self.get_header(), element_pointer_type)
 
 
 @_register_printer
@@ -638,43 +631,6 @@ class BoostIntrusiveTreeIterator:
 # boost::intrusive::list                         #
 ##################################################
 
-class BoostIntrusiveListIterator:
-    def __init__(self, listHeader, elementPointerType, memberOffset=0):
-        self.header = listHeader
-        self.memberOffset = memberOffset
-        if memberOffset == 0:
-            self.nodeType = elementPointerType
-        else:
-            self.nodeType = gdb.lookup_type("boost::intrusive::list_node<void*>").pointer();
-            self.elementPointerType = elementPointerType
-        nextNode = listHeader['next_']
-        if nextNode != listHeader.address:
-            self.node = nextNode.cast(self.nodeType)
-        else:
-            self.node = 0
-
-    def __iter__(self):
-        return self
-
-    def getElementPointerFromNodePointer(self):
-        if self.memberOffset == 0:
-            return self.node
-        else:
-            currentElementAddress = self.node.cast(gdb.lookup_type("size_t")) - self.memberOffset
-            return currentElementAddress.cast(self.elementPointerType)
-
-    def next(self):
-        # empty list or reached end
-        if not self.node:
-            raise StopIteration
-        result = self.getElementPointerFromNodePointer()
-        nextNode = self.node['next_']
-        if nextNode != self.header.address:
-            self.node = nextNode.cast(self.nodeType)
-        else:
-            self.node = 0
-        return result
-
 @_register_printer
 class BoostIntrusiveList:
     "Pretty Printer for boost::intrusive::list (Boost.Intrusive)"
@@ -682,16 +638,45 @@ class BoostIntrusiveList:
     version = '1.40'
     type_name_re = '^boost::intrusive::list<.*>$'
 
-    class _iter:
-        def __init__(self, listiter):
-            self.listiter = listiter
+    class Iterator:
+        def __init__(self, list_header, element_pointer_type, member_offset=0):
+            self.header = list_header
+
+            self.member_offset = member_offset
+            if member_offset == 0:
+                self.node_type = element_pointer_type
+            else:
+                self.node_type = gdb.lookup_type("boost::intrusive::list_node<void*>").pointer();
+                self.element_pointer_type = element_pointer_type
+
+            next_node = list_header['next_']
+            if next_node != list_header.address:
+                self.node = next_node.cast(self.node_type)
+            else:
+                self.node = 0
+
             self.count = 0
 
         def __iter__(self):
             return self
 
+        def get_element_pointer_from_node_pointer(self):
+            if self.member_offset == 0:
+                return self.node
+            else:
+                current_element_address = self.node.cast(gdb.lookup_type("size_t")) - self.member_offset
+                return current_element_address.cast(self.element_pointer_type)
+
         def next(self):
-            item = self.listiter.next().dereference()
+            # empty list or reached end
+            if not self.node:
+                raise StopIteration
+            item = self.get_element_pointer_from_node_pointer().dereference()
+            next_node = self.node['next_']
+            if next_node != self.header.address:
+                self.node = next_node.cast(self.node_type)
+            else:
+                self.node = 0
             result = ('[%d]' % self.count, item)
             self.count = self.count + 1
             return result
@@ -699,39 +684,39 @@ class BoostIntrusiveList:
     def __init__(self, value):
         self.typename = value.type_name
         self.val = value
-        self.elementType = self.val.type.strip_typedefs().template_argument(0)
+        self.element_type = self.val.type.strip_typedefs().template_argument(0)
 
-    def getHeader(self):
+    def get_header(self):
         return self.val["data_"]["root_plus_size_"]["root_"]
 
-    def getSize(self):
+    def get_size(self):
         return self.val["data_"]["root_plus_size_"]["size_"]
 
-    def hasElements(self):
-        header = self.getHeader()
-        firstElement = header["next_"]
-        rootElement = header.address
-        if firstElement != rootElement:
+    def has_elements(self):
+        header = self.get_header()
+        first_element = header["next_"]
+        root_element = header.address
+        if first_element != root_element:
             return True
         else:
             return False
 
-    def to_string (self):
+    def to_string(self):
         if (intrusive_container_has_size_member(self.val.type)):
-            return "boost::intrusive::list<%s> with %d elements" % (self.elementType, self.getSize())
-        elif (self.hasElements()):
-            return "non-empty boost::intrusive::list<%s>" % self.elementType
+            return "boost::intrusive::list<%s> with %d elements" % (self.element_type, self.get_size())
+        elif (self.has_elements()):
+            return "non-empty boost::intrusive::list<%s>" % self.element_type
         else:
-            return "empty boost::intrusive::list<%s>" % self.elementType
+            return "empty boost::intrusive::list<%s>" % self.element_type
 
-    def children (self):
-        elementPointerType = self.elementType.pointer()
+    def children(self):
+        element_pointer_type = self.element_type.pointer()
         member_hook = get_named_template_argument(self.val.type, "boost::intrusive::member_hook")
         if member_hook:
-            memberOffset = member_hook.template_argument(2).cast(gdb.lookup_type("size_t"))
-            return self._iter (BoostIntrusiveListIterator(self.getHeader(), elementPointerType, memberOffset))
+            member_offset = member_hook.template_argument(2).cast(gdb.lookup_type("size_t"))
+            return self.Iterator(self.get_header(), element_pointer_type, member_offset)
         else:
-            return self._iter (BoostIntrusiveListIterator(self.getHeader(), elementPointerType))
+            return self.Iterator(self.get_header(), element_pointer_type)
 
 @_register_printer
 class BoostIntrusiveListIterator:


### PR DESCRIPTION
When I recently tried to use the pretty printer for boost::intrusive::list in a new environment it just didn't work. Turned out the problem is a name clash. The name BoostIntrusiveListIterator was used for both the pretty printer and an internal helper. I don't know why things used to work anyway, but it doesn't matter. This commit fixes the problem (and I made the corresponding fix for boost::intrusive::set).

The pretty printer for boost::intrusive::set had a bug that caused a bogus element to be printed for an empty set. Also fixed.

I also took the opportunity to clean up some formatting issues local to boost::intrusive::set/boost::intrusive::list (mainly got rid of the camel case).
