### PR TITLE
Register printers with replace option.

### DIFF
--- a/boost/printers.py
+++ b/boost/printers.py
@@ -160,7 +160,7 @@ def register_printer_gen(obj):
     global printer_gen
 
     if _have_gdb_printing:
-        gdb.printing.register_pretty_printer(obj, printer_gen)
+        gdb.printing.register_pretty_printer(obj, printer_gen, replace=True)
     else:
         if obj is None:
             obj = gdb


### PR DESCRIPTION
This makes development easier because now an updated version of the
printers just replaces the old version.
