### PR TITLE
Minimal support for boost::type_erasure::any.

### DIFF
--- a/boost/__init__.py
+++ b/boost/__init__.py
@@ -40,6 +40,7 @@ from . import unordered_containers
 from . import intrusive_1_55
 from . import intrusive_1_40
 from . import multi_index_1_42
+from . import type_erasure
 from .utils import register_printers, add_trivial_printer, options, last_supported_boost_version
 from . import datetime
 from . import variant

--- a/boost/type_erasure.py
+++ b/boost/type_erasure.py
@@ -1,0 +1,22 @@
+# encoding: utf-8
+from __future__ import print_function, absolute_import, division
+import gdb
+from .utils import *
+
+#
+# Boost TypeErasure
+
+@add_printer
+class BoostTypeErasure:
+    "Pretty Printer for boost::type_erasure::any (Boost.TypeErasure)"
+    printer_name = 'boost::type_erasure::any'
+    min_supported_version = (1, 54, 0)
+    max_supported_version = last_supported_boost_version
+    template_name = 'boost::type_erasure::any'
+
+    def __init__(self, value):
+        self.value = value
+
+    def to_string(self):
+        stored_value = self.value['_boost_type_erasure_data']['data']
+        return '(boost::type_erasure::any<...> data = {})'.format(stored_value)


### PR DESCRIPTION
Just print the address of actual data.

You can get outputs as follows:

```
(gdb) p multi_index_container
$1 = boost::type_erasure::any<...> data = 0x555555571f10
```

If you know the acutual type, then you can cast as follows:

```
(gdb) p *(ActualType)0x555555571f10
```