### PR TITLE
Cast intrusive_ptr's pointer to its dynamic_type before dereferencing

### DIFF
--- a/boost/printers.py
+++ b/boost/printers.py
@@ -183,7 +183,7 @@ class BoostScopedPtr:
 
     def children(self):
         if self.value['px'] != 0:
-            yield 'value', self.value['px'].dereference()
+            yield 'value', self.value['px'].cast(self.value['px'].dynamic_type).dereference()
 
 
 @add_printer

--- a/tests/testsuite.cpp
+++ b/tests/testsuite.cpp
@@ -111,11 +111,20 @@ void test_intrusive_ptr()
 	struct S: public boost::intrusive_ref_counter<S>
 	{
 		int i;
+		virtual ~S() = default;
+	};
+
+	struct T: public S
+	{
+		int j;
 	};
 
 	boost::intrusive_ptr<S> intrusive_empty;
-	boost::intrusive_ptr<S> intrusive(new S);
-	intrusive->i = 42;
+	boost::intrusive_ptr<S> intrusive_base(new S);
+	boost::intrusive_ptr<S> intrusive_derived(new T);
+	intrusive_base->i = 42;
+	intrusive_derived->i = 6;
+	static_cast<T*>(intrusive_derived.get())->j = 9;
 #endif
 break_here:
 	dummy_function();

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -247,12 +247,20 @@ class IntrusivePtrTest(PrettyPrinterTest):
         self.assertEqual(children, [])
         self.assertIsNone(display_hint)
 
-    def test_intrusive(self):
-        string, children, display_hint = self.get_printer_result('intrusive')
+    def test_intrusive_base(self):
+        string, children, display_hint = self.get_printer_result('intrusive_base')
         self.assertNotEqual(string, 'uninitialized')
         children_as_struct = as_struct(children)
         self.assertEqual(set(children_as_struct), {'value'})
         self.assertEqual(children_as_struct['value']['i'], 42)
+        self.assertIsNone(display_hint)
+
+    def test_intrusive_derived(self):
+        string, children, display_hint = self.get_printer_result('intrusive_derived')
+        self.assertNotEqual(string, 'uninitialized')
+        children_as_struct = as_struct(children)
+        self.assertEqual(set(children_as_struct), {'value'})
+        self.assertEqual(children_as_struct['value']['j'], 9)
         self.assertIsNone(display_hint)
 
 


### PR DESCRIPTION
I use boost::intrusive_ptr with the root of a class hierarchy.
It would be useful to see the members of derived types in gdb.

Before:
```
(gdb) p intrusive_derived
$1 = 0x555555ae2990 = {
  value = {
    <boost::sp_adl_block::intrusive_ref_counter<test_intrusive_ptr()::S, boost::sp_adl_block::thread_safe_counter>> = {
      m_ref_counter = {
        value_ = {
          <std::__atomic_base<int>> = {
            _M_i = 1
          }, <No data fields>}
      }
    }, 
    members of S: 
    _vptr.S = 0x5555557c12f0 <vtable for test_intrusive_ptr()::T+16>, 
    i = 6
  }
}
```

After:
```
(gdb) p intrusive_derived
$1 = 0x555555ae2990 = {
  value = {
    <S> = {
      <boost::sp_adl_block::intrusive_ref_counter<test_intrusive_ptr()::S, boost::sp_adl_block::thread_safe_counter>> = {
        m_ref_counter = {
          value_ = {
            <std::__atomic_base<int>> = {
              _M_i = 1
            }, <No data fields>}
        }
      }, 
      members of S: 
      _vptr.S = 0x5555557c12f0 <vtable for test_intrusive_ptr()::T+16>, 
      i = 6
    }, 
    members of T: 
    j = 9
  }
}
```