### PR TITLE
Introduce workaround for label breakpoint issue

### DIFF
--- a/tests/testsuite.cpp
+++ b/tests/testsuite.cpp
@@ -315,6 +315,7 @@ void test_intrusive_set_base()
 	auto iter_1 = std::next(bset_1.begin());
 	auto iter_2 = std::next(bset_2.begin());
 break_here:
+	dummy_function();
 	bset_1.clear();
 	bset_2.clear();
 }
@@ -361,6 +362,7 @@ void test_intrusive_member_set()
 	auto iter2 = member_set_2.begin();
 
 break_here:
+	dummy_function();
 	member_set_1.clear();
 	member_set_2.clear();
 }
@@ -405,6 +407,7 @@ void test_intrusive_rbtree_set_member()
 	auto iter1 = member_set_1.begin();
 	auto iter2 = member_set_2.begin();
 break_here:
+	dummy_function();
 	member_set_1.clear();
 	member_set_2.clear();
 }
@@ -448,6 +451,7 @@ void test_intrusive_avl_set_member()
 	auto iter1 = member_set_1.begin();
 	auto iter2 = member_set_2.begin();
 break_here:
+	dummy_function();
 	member_set_1.clear();
 	member_set_2.clear();
 }
@@ -491,6 +495,7 @@ void test_intrusive_splay_set_member()
 	auto iter1 = member_set_1.begin();
 	auto iter2 = member_set_2.begin();
 break_here:
+	dummy_function();
 	member_set_1.clear();
 	member_set_2.clear();
 }
@@ -534,6 +539,7 @@ void test_intrusive_sg_set_member()
 	auto iter1 = member_set_1.begin();
 	auto iter2 = member_set_2.begin();
 break_here:
+	dummy_function();
 	member_set_1.clear();
 	member_set_2.clear();
 }

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -30,9 +30,11 @@ def execute_cpp_function(function_name):
     breakpoint_location = '{}:break_here'.format(function_name)
     bp = gdb.Breakpoint(breakpoint_location, internal=True)
     bp.silent = True
+    bp.commands = 'advance dummy_function'
     gdb.execute('run')
     assert bp.hit_count == 1
     bp.delete()
+    gdb.execute('finish')   # exit dummy_function, return to test function
 
 
 def to_python_value(value):


### PR DESCRIPTION
In gcc 8 and 9 I observe that setting a breakpoint on the `break_here`
labels is unreliable, and sometimes results in a transfer of control
to the code right before the label, instead of right after. This workaround
causes gdb to run to directly after the subsequent `dummy_function`,
where the test function's locals are still in scope.